### PR TITLE
Some xml errors wont display error output in vim-xpath

### DIFF
--- a/xpath/xpath.py
+++ b/xpath/xpath.py
@@ -452,8 +452,11 @@ class XPathParseErrorResult(XPathErrorResult):
 
   def first_group_match(self, pattern, text):
     search = re.search(pattern, text)
-    groups = search.groups()
-    return groups[0]
+    if search is not None:
+      groups = search.groups()
+      return groups[0]
+    else:
+      return None
 
 class XPathSearchErrorResult(XPathErrorResult):
   def __init__(self, error, xpath):


### PR DESCRIPTION
re.search() can return None, if it does don't try to return non-existant
restults
