### PR TITLE
Some errors don't have line or column, return None

### DIFF
--- a/xpath/xpath.py
+++ b/xpath/xpath.py
@@ -439,8 +439,11 @@ class XPathParseErrorResult(XPathErrorResult):
 
   def first_group_match(self, pattern, text):
     search = re.search(pattern, text)
-    groups = search.groups()
-    return groups[0]
+    if search is not None:
+      groups = search.groups()
+      return groups[0]
+    else:
+      return None
 
 class XPathSearchErrorResult(XPathErrorResult):
   def __init__(self, error, xpath):


### PR DESCRIPTION
re.search() can return None, if it does don't try to return non-existent
results

(sorry that the previous pull request was from master instead of a feature branch)
