### PR TITLE
Add g:quiet_xpath option

### DIFF
--- a/doc/xpath.txt
+++ b/doc/xpath.txt
@@ -142,6 +142,12 @@ following in your |vimrc|:
 
 let g:skip_xpath = 1
 
+To make vim-xpath quiet during the python and lxml detection, (e.g. to hide
+the startup messages in case of autodetction failure) add the following in
+your |vimrc|:
+
+let g:quiet_xpath = 1
+
 Common namespaces can be configured globally by defining a g:ns_prefixes
 variable:
 

--- a/plugin/vim-xpath.vim
+++ b/plugin/vim-xpath.vim
@@ -5,10 +5,13 @@ endif
 
 "Check python is installed
 if !has("python")
-    echo 'vim-xpath requires vim to be compiled with python support, and '
-                \ . 'python to be installed. To stop this message from '
-                \ . 'appearing, either install python, uninstall this plugin '
-                \ . 'or add the line "let g:skip_xpath = 1" to your vimrc.'
+    if !exists("g:quiet_xpath")
+        echo 'vim-xpath requires vim to be compiled with python support, and '
+                    \ . 'python to be installed. To stop this message from '
+                    \ . 'appearing, either install python, uninstall this plugin '
+                    \ . 'or add the line "let g:skip_xpath = 1" to your vimrc.'
+    endif
+
     finish
 endif
 
@@ -24,10 +27,13 @@ except ImportError:
 EOF
 
 if s:no_lxml
-    echo 'vim-xpath requires the lxml python library (http://lxml.de) to be '
-                \ . 'installed. To stop this message from appearing, either '
-                \ . 'install lxml, uninstall this plugin or add the line '
-                \ . '"let g:skip_xpath = 1" to your vimrc.'
+    if !exists("g:quiet_xpath")
+        echo 'vim-xpath requires the lxml python library (http://lxml.de) to be '
+                    \ . 'installed. To stop this message from appearing, either '
+                    \ . 'install lxml, uninstall this plugin or add the line '
+                    \ . '"let g:skip_xpath = 1" to your vimrc.'
+    endif
+
     finish
 endif
 


### PR DESCRIPTION
When using a vim configuration shared amongst many boxes, you
might want to silent autodetection messages.