### PR TITLE
Handle KeyError for buffer offset in neovim

### DIFF
--- a/python/vim_adaptor.py
+++ b/python/vim_adaptor.py
@@ -18,6 +18,8 @@ def get_buffer_string(bufnr):
         vim.buffers[0]
     except ValueError:
         offset = 0
+    except KeyError:
+        offset = 0
 
     buffer = vim.buffers[bufnr + offset]
     return "\n".join(buffer)


### PR DESCRIPTION
Buffer indexing is different in NeoVim, and the vim-python interface throws a different error when we're testing the waters (I think). This seems to work in Neovim and regular vim.